### PR TITLE
replace yaml.load by yaml.safe_load for security reasons

### DIFF
--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -111,7 +111,7 @@ class TestrailReporter(Reporter):
         try:
             with open('testrail.yml', 'r') as stream:
                 try:
-                    self.config = yaml.load(stream)
+                    self.config = yaml.safe_load(stream)
                     self._load_projects_from_config(self.config)
                 except yaml.YAMLError as exception:
                     raise Exception('Error loading testrail.yml file: {}'.format(exception))
@@ -143,7 +143,7 @@ class TestrailReporter(Reporter):
         """
 
         try:
-            validate(config, yaml.load(schema))
+            validate(config, yaml.safe_load(schema))
         except Exception as exception:
             raise Exception(
                 'Invalid testrail.yml file! error: {}'.format(exception.message))

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     description='Behave library to integrate with Testrail API',
     keywords=['Behave', 'Testrail', 'API', 'Test', 'BDD'],
     long_description=long_description,
+    long_description_content_type='text/markdown',
     install_requires=requirements,
     classifiers=[
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
- [x] Improve security by replacing `yaml.load` by `yaml.safe_load`