### PR TITLE
Ensure elapsed timespan minimum is 1

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,12 @@
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once).
+disable=R0201

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -229,6 +229,17 @@ class TestrailReporter(Reporter):
 
         return comment
 
+    @classmethod
+    def _format_duration(cls, duration):
+        """
+        This function ensure the minimum duration is 1s to prevent Testrail API error:
+            Field :elapsed is not in a valid time span format.
+        Returns a string formatted as (duration_in_seconds + 's')
+        """
+        duration_seconds = max(1, int(duration))
+
+        return '{duration_seconds}s'.format(duration_seconds=duration_seconds)
+
     def process_scenario(self, scenario):
         """
         Reports the test results for the given scenario to the testrail run.

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -270,7 +270,7 @@ class TestrailReporter(Reporter):
                             case_id=case_id,
                             status=testrail_status,
                             comment=comment,
-                            elapsed=scenario.duration,
+                            elapsed_seconds=scenario.duration,
                         )
 
                         if is_added:

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -209,7 +209,7 @@ class TestrailReporter(Reporter):
 
         return self.testrail_client
 
-    def _add_test_result(self, project, case_id, status, comment='', elapsed='0'):
+    def _add_test_result(self, project, case_id, status, comment='', elapsed='1'):
         if not project.test_run:
             self.setup_test_run(project)
 

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -209,18 +209,18 @@ class TestrailReporter(Reporter):
 
         return self.testrail_client
 
-    def _add_test_result(self, project, case_id, status, comment='', elapsed='1'):
+    def _add_test_result(self, project, case_id, status, comment='', elapsed_seconds=1):
         if not project.test_run:
             self.setup_test_run(project)
 
-        elapsed_time_formatted = self._format_duration(elapsed)
+        elapsed_seconds_formatted = self._format_duration(elapsed_seconds)
 
         return self._get_testrail_client().create_result(
             project.test_run['id'],
             case_id,
             status=status,
             comment=comment,
-            elapsed=elapsed_time_formatted,
+            elapsed=elapsed_seconds_formatted,
         )
 
     @classmethod

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -220,7 +220,7 @@ class TestrailReporter(Reporter):
             case_id,
             status=status,
             comment=comment,
-            elapsed=elapsed_time_formatted
+            elapsed=elapsed_time_formatted,
         )
 
     @classmethod
@@ -272,7 +272,7 @@ class TestrailReporter(Reporter):
                             case_id=case_id,
                             status=testrail_status,
                             comment=comment,
-                            elapsed=scenario.duration
+                            elapsed=scenario.duration,
                         )
 
                         if is_added:

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -213,12 +213,14 @@ class TestrailReporter(Reporter):
         if not project.test_run:
             self.setup_test_run(project)
 
+        elapsed_time_formatted = self._format_duration(elapsed)
+
         return self._get_testrail_client().create_result(
             project.test_run['id'],
             case_id,
             status=status,
             comment=comment,
-            elapsed=elapsed
+            elapsed=elapsed_time_formatted
         )
 
     @classmethod
@@ -270,7 +272,7 @@ class TestrailReporter(Reporter):
                             case_id=case_id,
                             status=testrail_status,
                             comment=comment,
-                            elapsed='%ds' % int(scenario.duration)
+                            elapsed=scenario.duration
                         )
 
                         if is_added:

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -223,16 +223,14 @@ class TestrailReporter(Reporter):
             elapsed=elapsed_seconds_formatted,
         )
 
-    @classmethod
-    def _buid_comment_for_scenario(cls, scenario):
+    def _buid_comment_for_scenario(self, scenario):
         comment = '{}\n'.format(scenario.name)
         comment += '\n'.join(
             ['->  {} {} [{}]'.format(step.keyword, step.name, step.status) for step in scenario.steps])
 
         return comment
 
-    @classmethod
-    def _format_duration(cls, duration):
+    def _format_duration(self, duration):
         """
         This function ensure the minimum duration is 1s to prevent Testrail API error:
             Field :elapsed is not in a valid time span format.

--- a/test/test_testrail_reporter.py
+++ b/test/test_testrail_reporter.py
@@ -70,6 +70,13 @@ class TestrailReporterTestCase(unittest.TestCase):
 
         self.assertEquals('69s', formatted_duration)
 
+    def test_format_duration_return_one_for_zero_durations(self):
+        testrail_reporter = TestrailReporter('master')
+        duration = 0
+        formatted_duration = testrail_reporter._format_duration(duration)
+
+        self.assertEquals('1s', formatted_duration)
+
 
 class TestrailReporterTestLoadConfig(unittest.TestCase):
     def test_config_file_is_not_present(self):

--- a/test/test_testrail_reporter.py
+++ b/test/test_testrail_reporter.py
@@ -63,6 +63,13 @@ class TestrailReporterTestCase(unittest.TestCase):
             '->  given step_02 [passed]')
         self.assertEqual(expected_comment, comment)
 
+    def test_format_duration(self):
+        testrail_reporter = TestrailReporter('master')
+        duration = 69
+        formatted_duration = testrail_reporter._format_duration(duration)
+
+        self.assertEquals('69s', formatted_duration)
+
 
 class TestrailReporterTestLoadConfig(unittest.TestCase):
     def test_config_file_is_not_present(self):


### PR DESCRIPTION
- [x] Ensure elapsed time sent to Testrail is never 0 to prevent API error

Example of the Testrail API error when posting `elapsed='0s'`:

```json
{"error":"Field :elapsed is not in a valid time span format."}
```

This is a known issue and [is listed here](https://discuss.gurock.com/t/elapsed-field-datatype-api-question/1089/10).

Testrail recommendation is to round to the nearest second for now.