### PR TITLE
Allow to customise test run name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0] - 2018-07-20
+### Changed
+- You can now customise the test run name using a few variables.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Example structure:
 ```yaml
 projects:
   -
-    name: 'Project Name'
+    name: 'Test run {master}'
     id: 123
-    suite_id: 123
+    suite_id: 456
     allowed_branch_pattern: '^(master|release\/\d+([\.\d]+)?)$'
 ```
 
@@ -65,6 +65,14 @@ projects:
 | id                     | Testrail project id                                        |  
 | suite_id               | Testrail Suite id                                          |  
 | allowed_branch_pattern | Regular expression to restrict when a test run is executed |  
+
+**name** - You can use some project variables to create dynamic test run names
+
+| Variable     | Example                 | Result          |
+| ------------ | ----------------------- | --------------- |
+| {project_id} | 'Test run {project_id}' | Test run 123    |
+| {suite_id}   | 'Test run {suite_id}'   | Test run 456    |
+| {branch}     | 'Test run {suite_id}'   | Test run master |
 
 
 **Environment variables required**

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Example structure:
 ```yaml
 projects:
   -
-    name: 'Test run {master}'
+    name: 'Test run {branch}'
     id: 123
     suite_id: 456
     allowed_branch_pattern: '^(master|release\/\d+([\.\d]+)?)$'

--- a/behave_testrail_reporter/__init__.py
+++ b/behave_testrail_reporter/__init__.py
@@ -1,1 +1,1 @@
-from .testrail_reporter import TestrailReporter  # noqa: F401
+from .testrail_reporter import TestrailReporter, TestrailProject  # noqa: F401

--- a/behave_testrail_reporter/api.py
+++ b/behave_testrail_reporter/api.py
@@ -69,11 +69,11 @@ class APIClient:
         else:
             return response.json()
 
-    def create_run(self, project_id, suite_id, name):
+    def create_run(self, project_id, suite_id, test_run_name):
         uri_create_test_run = u'add_run/{}'.format(project_id)
         post_data = {
             u'suite_id': suite_id,
-            u'name': name,
+            u'name': test_run_name,
             u'include_all': True,
         }
 

--- a/behave_testrail_reporter/api.py
+++ b/behave_testrail_reporter/api.py
@@ -79,11 +79,11 @@ class APIClient:
 
         return self.send_post(uri=uri_create_test_run, data=post_data)
 
-    def get_run_for_branch(self, project_id, branch_name):
+    def get_test_run_by_project_and_name(self, project_id, test_run_name):
         uri_get_project_test_runs = u'get_runs/{project_id}&is_completed=0'.format(project_id=project_id)
         response = self.send_get(uri=uri_get_project_test_runs)
         for test_run in response:
-            if test_run[u'name'] == branch_name:
+            if test_run[u'name'] == test_run_name:
                 return test_run
         return None
 

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -51,7 +51,6 @@ class TestrailProject(object):
         return self.name.format(
             project_id=self.id,
             suite_id=self.suite_id,
-            name=self.name,
             branch=branch_name)
 
 

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -186,14 +186,13 @@ class TestrailReporter(Reporter):
         """
         Sets up the testrail run for testrail_project.
         """
-        testrail_project.test_run = self._get_testrail_client().get_run_for_branch(
-            testrail_project.id,
-            self.branch_name
+        test_run_name = testrail_project.get_test_run_name(branch_name=self.branch_name)
+        testrail_project.test_run = self._get_testrail_client().get_test_run_by_project_and_name(
+            project_id=testrail_project.id,
+            test_run_name=test_run_name
         )
 
         if testrail_project.test_run is None:
-            # @todo allow to customise the test run name that is created
-            test_run_name = self.branch_name
             testrail_project.test_run = self._get_testrail_client().create_run(
                 testrail_project.id,
                 testrail_project.suite_id,

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -39,14 +39,21 @@ def format_summary(statement_type, summary):
 
 
 class TestrailProject(object):
-    def __init__(self, id, name, suite_id, test_run_name='', allowed_branch_pattern='*'):
+    def __init__(self, id, name, suite_id, allowed_branch_pattern='*', name_pattern='{branch}'):
         self.id = id
         self.name = name
         self.suite_id = suite_id
-        self.test_run_name = test_run_name
         self.allowed_branch_pattern = allowed_branch_pattern
         self.test_run = None
         self.cases = {}
+        self.test_run_name_pattern = name_pattern
+
+    def get_test_run_name(self, branch_name):
+        return self.test_run_name_pattern.format(
+            project_id=self.id,
+            suite_id=self.suite_id,
+            name=self.name,
+            branch=branch_name)
 
 
 class TestrailReporter(Reporter):

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -39,17 +39,16 @@ def format_summary(statement_type, summary):
 
 
 class TestrailProject(object):
-    def __init__(self, id, name, suite_id, allowed_branch_pattern='*', name_pattern='{branch}'):
+    def __init__(self, id, name, suite_id, allowed_branch_pattern='*'):
         self.id = id
         self.name = name
         self.suite_id = suite_id
         self.allowed_branch_pattern = allowed_branch_pattern
         self.test_run = None
         self.cases = {}
-        self.test_run_name_pattern = name_pattern
 
     def get_test_run_name(self, branch_name):
-        return self.test_run_name_pattern.format(
+        return self.name.format(
             project_id=self.id,
             suite_id=self.suite_id,
             name=self.name,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ test_requirements = ['coverage', 'flake8', 'mock', 'twine', 'codacy-coverage']
 
 setup(
     name='behave-testrail-reporter',
-    version='0.2.0',
+    version='0.3.0',
     author='Virtualstock',
     author_email='development.team@virtualstock.co.uk',
     url='https://github.com/virtualstock/behave-testrail-reporter/',

--- a/test/test_testrail_reporter.py
+++ b/test/test_testrail_reporter.py
@@ -10,7 +10,7 @@ from mock import Mock
 from behave.model import Scenario
 
 from behave_testrail_reporter.api import APIClient
-from behave_testrail_reporter import TestrailReporter
+from behave_testrail_reporter import TestrailReporter, TestrailProject
 
 
 class TestrailReporterTestCase(unittest.TestCase):
@@ -153,3 +153,35 @@ class TestrailReporterTestLoadConfig(unittest.TestCase):
 
         exception_message = u'Your testrail.yml config file does not have any project configured!'
         self.assertEquals(exception_message, context.exception.args[0])
+
+
+class TestrailProjectTestCase(unittest.TestCase):
+    def test_get_test_run_name_default(self):
+        project = TestrailProject(1, u'master', 3)
+        test_run_name = project.get_test_run_name(branch_name=u'master')
+
+        self.assertEquals(u'master', test_run_name)
+
+    def test_get_test_run_name_branch(self):
+        project = TestrailProject(1, u'My Test Suite {branch}', 3, u'')
+        test_run_name = project.get_test_run_name(branch_name=u'master')
+
+        self.assertEquals(u'My Test Suite master', test_run_name)
+
+    def test_get_test_run_name_project_id(self):
+        project = TestrailProject(1, u'My Test Suite {project_id}', 3)
+        test_run_name = project.get_test_run_name(branch_name=u'master')
+
+        self.assertEquals(u'My Test Suite 1', test_run_name)
+
+    def test_get_test_run_name_suite_id(self):
+        project = TestrailProject(1, u'My Test Suite {suite_id}', 3)
+        test_run_name = project.get_test_run_name(branch_name=u'master')
+
+        self.assertEquals(u'My Test Suite 3', test_run_name)
+
+    def test_get_test_run_name_combined_vars(self):
+        project = TestrailProject(1, u'My Test Suite {branch} {project_id} {suite_id}', 3)
+        test_run_name = project.get_test_run_name(branch_name=u'master')
+
+        self.assertEquals(u'My Test Suite master 1 3', test_run_name)


### PR DESCRIPTION
This should allow to create dynamic test run names.
This way we can have one suite fixed name and a variable to make it generate different test runs.

This solves a blocking issues of having multiple suites in the same project that run in the same branch