### PR TITLE
ensure environment variables are defined when using reporter to avoid silent errors

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,3 +10,6 @@
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
 disable=R0201
+
+[FORMAT]
+max-line-length=120

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,7 @@
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-disable=R0201
+disable=no-self-use, missing-docstring
 
 [FORMAT]
 max-line-length=120

--- a/behave_testrail_reporter/api.py
+++ b/behave_testrail_reporter/api.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-
+import os
 import textwrap
+
 import requests
 
 
@@ -15,15 +16,23 @@ class APIClient:
     with additional abstractions for certain operations.
     """
 
-    def __init__(self, base_url, username, password):
-        self.user = username
-        self.password = password
+    def __init__(self, base_url):
+        self.user = os.environ.get(u'TESTRAIL_USER')
+        self.password = os.environ.get(u'TESTRAIL_KEY')
+
         if not base_url.endswith(u'/'):
             base_url += u'/'
         self.url = base_url + u'index.php?/api/v2/'
         self.session = requests.Session()
         self.session.auth = (self.user, self.password)
         self.session.headers.update({u'Content-Type': u'application/json'})
+
+        if not self.user or not self.password:
+            raise ValueError(
+                u'Environment variables to authenticate on Testrail API are not defined!\n'
+                u'Please define those environment variables: \n'
+                u'TESTRAIL_USER and TESTRAIL_KEY'
+            )
 
     def _build_endpoint_from_uri(self, uri):
         return u'{base_url}{uri}'.format(base_url=self.url, uri=uri)

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -77,10 +77,6 @@ class TestrailReporter(Reporter):
     def __init__(self, branch_name):
         self.config = {}
         self.projects = []
-        self.username = os.environ.get(u'TESTRAIL_USER')
-        self.secret_key = os.environ.get(u'TESTRAIL_KEY')
-        # @todo ensure username and secret_key are set
-        # @todo ensure project_id and suite_id are set
         self.branch_name = branch_name
         self.testrail_client = None
         self.testrail_run = None
@@ -207,11 +203,7 @@ class TestrailReporter(Reporter):
 
     def _get_testrail_client(self):
         if not self.testrail_client:
-            self.testrail_client = APIClient(
-                base_url=self.config.get(u'base_url'),
-                username=self.username,
-                password=self.secret_key,
-            )
+            self.testrail_client = APIClient(base_url=self.config.get(u'base_url'))
 
         return self.testrail_client
 

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import re
-import os
 import yaml
 
 from jsonschema import validate

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -2,17 +2,12 @@
 
 import unittest
 import os
+import mock
 
 from behave_testrail_reporter.api import APIClient
 
 
 class APIClientTestCase(unittest.TestCase):
-    def setUp(self):
-        if os.environ.get(u'TESTRAIL_USER'):
-            del os.environ[u'TESTRAIL_USER']
-        if os.environ.get(u'TESTRAIL_KEY'):
-            del os.environ[u'TESTRAIL_KEY']
-
     def test_env_variables_not_present(self):
         with self.assertRaises(ValueError) as context:
             APIClient(base_url='index.php/')
@@ -22,22 +17,24 @@ class APIClientTestCase(unittest.TestCase):
         )
 
     def test_env_variables_user_not_present(self):
-        os.environ[u'TESTRAIL_KEY'] = u'simpson123'
+        test_environment = {u'TESTRAIL_USER': u'', u'TESTRAIL_KEY': u'simpson123'}
 
-        with self.assertRaises(ValueError):
-            APIClient(base_url='index.php/')
+        with mock.patch.dict(os.environ, test_environment):
+            with self.assertRaises(ValueError):
+                APIClient(base_url='index.php/')
 
     def test_env_variables_key_not_present(self):
-        os.environ[u'TESTRAIL_USER'] = u'homer@springfield.test'
+        test_environment = {u'TESTRAIL_USER': u'homer@springfield.test', u'TESTRAIL_KEY': u'', }
 
-        with self.assertRaises(ValueError):
-            APIClient(base_url='index.php/')
+        with mock.patch.dict(os.environ, test_environment):
+            with self.assertRaises(ValueError):
+                APIClient(base_url='index.php/')
 
     def test_env_variables_user_and_pass(self):
-        os.environ[u'TESTRAIL_USER'] = u'homer@springfield.test'
-        os.environ[u'TESTRAIL_KEY'] = u'simpson123'
+        test_environment = {u'TESTRAIL_USER': u'homer@springfield.test', u'TESTRAIL_KEY': u'simpson123'}
 
-        api_client = APIClient(base_url='index.php/')
+        with mock.patch.dict(os.environ, test_environment):
+            api_client = APIClient(base_url='index.php/')
 
         self.assertEqual(u'homer@springfield.test', api_client.user)
         self.assertEqual(u'simpson123', api_client.password)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -12,9 +12,8 @@ class APIClientTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             APIClient(base_url='index.php/')
 
-        self.assertTrue(
-            'Environment variables to authenticate on Testrail API are not defined!' in str(context.exception)
-        )
+        expected_message = u'Environment variables to authenticate on Testrail API are not defined!'
+        self.assertTrue(expected_message in str(context.exception))
 
     def test_env_variables_user_not_present(self):
         test_environment = {u'TESTRAIL_USER': u'', u'TESTRAIL_KEY': u'simpson123'}

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -39,5 +39,5 @@ class APIClientTestCase(unittest.TestCase):
 
         api_client = APIClient(base_url='index.php/')
 
-        self.assertEquals(u'homer@springfield.test', api_client.user)
-        self.assertEquals(u'simpson123', api_client.password)
+        self.assertEqual(u'homer@springfield.test', api_client.user)
+        self.assertEqual(u'simpson123', api_client.password)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import os
+
+from behave_testrail_reporter.api import APIClient
+
+
+class APIClientTestCase(unittest.TestCase):
+    def setUp(self):
+        if os.environ.get(u'TESTRAIL_USER'):
+            del os.environ[u'TESTRAIL_USER']
+        if os.environ.get(u'TESTRAIL_KEY'):
+            del os.environ[u'TESTRAIL_KEY']
+
+    def test_env_variables_not_present(self):
+        with self.assertRaises(ValueError) as context:
+            APIClient(base_url='index.php/')
+
+        self.assertTrue(
+            'Environment variables to authenticate on Testrail API are not defined!' in str(context.exception)
+        )
+
+    def test_env_variables_user_not_present(self):
+        os.environ[u'TESTRAIL_KEY'] = u'simpson123'
+
+        with self.assertRaises(ValueError):
+            APIClient(base_url='index.php/')
+
+    def test_env_variables_key_not_present(self):
+        os.environ[u'TESTRAIL_USER'] = u'homer@springfield.test'
+
+        with self.assertRaises(ValueError):
+            APIClient(base_url='index.php/')
+
+    def test_env_variables_user_and_pass(self):
+        os.environ[u'TESTRAIL_USER'] = u'homer@springfield.test'
+        os.environ[u'TESTRAIL_KEY'] = u'simpson123'
+
+        api_client = APIClient(base_url='index.php/')
+
+        self.assertEquals(u'homer@springfield.test', api_client.user)
+        self.assertEquals(u'simpson123', api_client.password)


### PR DESCRIPTION
This will ensure developers don't forget to define environment variables on their CI
environment.
A common use case is when you change Continous Integration provider and forget to add
the environment variables to the build config.
This will make clear what the developer needs to do.