### PR TITLE
Remove Python 3.3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     install_requires=requirements,
     classifiers=[
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,13 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,33,34,35,36}, lint, coverage
+envlist = py{27,34,35,36}, lint, coverage
 skip_missing_interpreters = True
 
 [testenv]
 passenv = CODACY_PROJECT_TOKEN CIRCLE_SHA1 CIRCLE_WORKING_DIRECTORY
 basepython =
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
This version is no longer supported by wheel, so our tests are failing on PR #27 