### PR TITLE
Performance improvement and tidy up

### DIFF
--- a/behave_testrail_reporter/api.py
+++ b/behave_testrail_reporter/api.py
@@ -44,10 +44,10 @@ class APIClient:
             response.raise_for_status()
         except requests.HTTPError as e:
             error_template = textwrap.dedent(
-                u"""
-                            Error ({error}) during GET to endpoint: ({endpoint})
-                            Response Content: {response_content}
-                        """
+                u"""\
+                    Error ({error}) during GET to endpoint: ({endpoint})
+                    Response Content: {response_content}
+                """
             )
             error_message = error_template.format(
                 error=e.message, endpoint=uri, response_content=response.content
@@ -63,11 +63,11 @@ class APIClient:
             response.raise_for_status()
         except requests.HTTPError as e:
             error_template = textwrap.dedent(
-                u"""
-                Error ({error}) during POST to endpoint: ({endpoint})
-                With data: {data}
-                Response Content: {response_content}
-            """
+                u"""\
+                    Error ({error}) during POST to endpoint: ({endpoint})
+                    With data: {data}
+                    Response Content: {response_content}
+                """
             )
             error_message = error_template.format(
                 error=e.message,

--- a/behave_testrail_reporter/testrail_reporter.py
+++ b/behave_testrail_reporter/testrail_reporter.py
@@ -255,6 +255,12 @@ class TestrailReporter(Reporter):
                 case_id = tag[len(TestrailReporter.CASE_TAG_PREFIX) :]
                 # loop through all projects to ensure if test exists on both projects it is pushed
                 for testrail_project in self.projects:
+                    # If the branch is not allowed to generate a test run for
+                    # the project we just skip to the next project.
+                    if not self._can_generate_test_run_for_branch(
+                        testrail_project, self.branch_name
+                    ):
+                        continue
                     if not testrail_project.cases:
                         self._load_test_cases_for_project(testrail_project)
                     if case_id in testrail_project.cases:
@@ -265,12 +271,6 @@ class TestrailReporter(Reporter):
                         # When adding a test result untested status is not allowed status
                         # @see http://docs.gurock.com/testrail-api2/reference-results#add_result
                         if testrail_status is self.STATUS_UNTESTED:
-                            self.case_summary[Status.skipped.name] += 1
-                            continue
-
-                        if not self._can_generate_test_run_for_branch(
-                            testrail_project, self.branch_name
-                        ):
                             self.case_summary[Status.skipped.name] += 1
                             continue
 


### PR DESCRIPTION
- [x] Remove unnecessary new line on error templates
- [x] Improve performance by avoiding requests to Testrail endpoint for branches not allowed to create TestRuns

When running quite a few E2E tests in parallel we often see a bad gateway response, this PR should prevent this from happening since we only need to create test runs on release tags or master.
```
<head><title>502 Bad Gateway</title></head>
```