### PR TITLE
:bookmark: Bump library to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.5.0] - 2021-09-23
+### Changed
+- Handle new Testrail get cases paginated response to keep same behaviour of fetching all cases.
+
+
 ## [0.4.0] - 2019-06-28
 ### Changed
 - Avoid unnecessary requests to Testrail when a branch is not allowed to create Test Runs.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ TEST_REQUIREMENTS = ["coverage", "flake8", "mock", "twine", "codacy-coverage"]
 
 setup(
     name="behave-testrail-reporter",
-    version="0.4.0",
+    version="0.5.0",
     author="Virtualstock",
     author_email="development.team@virtualstock.co.uk",
     url="https://github.com/virtualstock/behave-testrail-reporter/",


### PR DESCRIPTION
Tagged 0.5.0 by mistake, so bumping straight to 0.5.1 to be aligned with next
tag.
